### PR TITLE
Correct output paths to match already existing files

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.3
+  VERSION: 0.1.4
   IMAGE_NAME: cpg-flow-gcnv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the gCNV workflow, migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gcnv.py) to the CPG-Flow framework.
 
-Current Version: 0.1.3
+Current Version: 0.1.4
 
 ## Purpose
 
@@ -41,7 +41,7 @@ Example Analysis-Runner invocation:
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gcnv:0.1.3 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gcnv:0.1.4 \
     --dataset DATASET \
     --description 'gCNV, CPG-flow' \
     -o gCNV_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='CPG-Flow implementation of the GCNV workflow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.11"
-version="0.1.3"
+version="0.1.4"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -126,7 +126,7 @@ hail = ["hail"]
 "src/cpg_gcnv/stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.3"
+current_version = "0.1.4"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_gcnv/config_template.toml
+++ b/src/cpg_gcnv/config_template.toml
@@ -16,7 +16,6 @@ exclude_intervals = ['chrM']
 # Aim for 10-50Mbp genomic coverage per shard
 interval_shards = [['chr1'], ['chr2', 'chr3'], ['chr4', 'chr5'], ['chr6', 'chr7'], ['chr8', 'chr9', 'chr10'], ['chr11', 'chr12'], ['chr13', 'chr14', 'chr15'], ['chr16', 'chr17'], ['chr18', 'chr19', 'chr20'], ['chr21', 'chr22', 'chrX', 'chrY']]
 allosomal_contigs = ['chrX', 'chrY']
-status_reporter = 'metamist'
 
 # This should be provided for each cohort, specific to the capture they were generated with
 #intervals_path = 'gs://cpg-common-test/gCNV_resources/SSCRE_V2_intervals.interval_list'
@@ -35,9 +34,11 @@ gncv_max_pass_events = 30
 
 [images]
 gatk_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2023-07-13-4.4.0.0-43-gd79823f9c-NIGHTLY-SNAPSHOT"
-gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
+#gatk_gcnv = 'australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:4.2.6.1-57-g9e03432'
 sv_base_mini_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images/sv/sv-base-mini:5994670"
-sv_pipeline_docker = "australia-southeast1-docker.pkg.dev/cpg-common/images-dev/gatk-sv_issue_661:n_a"
+
+gatk_gcnv='australia-southeast1-docker.pkg.dev/cpg-common/images/sv/gatk:2024-12-05-4.6.1.0-6-gfc248dfc1-NIGHTLY-SNAPSHOT'
+sv_pipeline_docker = 'australia-southeast1-docker.pkg.dev/cpg-common/images/gatk-sv_issue_661:n_a-1'
 bcftools_116 = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools:1.16"
 bcftools_120 = "australia-southeast1-docker.pkg.dev/cpg-common/images/bcftools_120:1.20"
 

--- a/src/cpg_gcnv/stages.py
+++ b/src/cpg_gcnv/stages.py
@@ -109,11 +109,13 @@ class DeterminePloidy(stage.CohortStage):
     """
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path]:
-        cohort_prefix = self.get_stage_cohort_prefix(cohort)
+        # output path for cohort-level results should be the workflow dataset / wf name / cohort id / stage / files
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / self.name
         return {
-            'filtered': cohort_prefix / 'filtered.interval_list',
-            'calls': cohort_prefix / 'ploidy-calls.tar.gz',
-            'model': cohort_prefix / 'ploidy-model.tar.gz',
+            'filtered': prefix / 'filtered.interval_list',
+            'calls': prefix / 'ploidy-calls.tar.gz',
+            'model': prefix / 'ploidy-model.tar.gz',
         }
 
     def queue_jobs(self, cohort: targets.Cohort, inputs: stage.StageInput) -> stage.StageOutput:
@@ -151,10 +153,11 @@ class UpgradePedWithInferred(stage.CohortStage):
     """
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path]:
-        cohort_prefix = self.get_stage_cohort_prefix(cohort)
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / self.name
         return {
-            'aneuploidy_samples': cohort_prefix / 'aneuploidies.txt',
-            'pedigree': cohort_prefix / 'inferred_sex_pedigree.ped',
+            'aneuploidy_samples': prefix / 'aneuploidies.txt',
+            'pedigree': prefix / 'inferred_sex_pedigree.ped',
         }
 
     def queue_jobs(self, cohort: targets.Cohort, inputs: stage.StageInput) -> stage.StageOutput:
@@ -179,7 +182,9 @@ class CallGermlineCnvsWithGatk(stage.CohortStage):
     """
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path]:
-        return {name: self.get_stage_cohort_prefix(cohort) / f'{name}.tar.gz' for name in shard_items(name_only=True)}
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / 'GermlineCNV'
+        return {name: prefix / f'{name}.tar.gz' for name in shard_items(name_only=True)}
 
     def queue_jobs(self, cohort: targets.Cohort, inputs: stage.StageInput) -> stage.StageOutput:
         outputs = self.expected_outputs(cohort)
@@ -217,15 +222,14 @@ class ProcessCohortCnvCallsToSgVcf(stage.SequencingGroupStage):
         # identify the cohort that contains this SGID
         this_cohort: targets.Cohort = get_cohort_for_sgid(seqgroup.id)
 
-        # this job runs per sample, on results with a cohort context
-        # so we need to write the outputs to a cohort-specific location
-        cohort_prefix = self.get_stage_cohort_prefix(this_cohort)
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / this_cohort.id / 'GermlineCNVCalls'
         return {
-            'intervals': cohort_prefix / f'{seqgroup.id}.intervals.vcf.gz',
-            'intervals_index': cohort_prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
-            'segments': cohort_prefix / f'{seqgroup.id}.segments.vcf.gz',
-            'segments_index': cohort_prefix / f'{seqgroup.id}.segments.vcf.gz.tbi',
-            'ratios': cohort_prefix / f'{seqgroup.id}.ratios.tsv',
+            'intervals': prefix / f'{seqgroup.id}.intervals.vcf.gz',
+            'intervals_index': prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
+            'segments': prefix / f'{seqgroup.id}.segments.vcf.gz',
+            'segments_index': prefix / f'{seqgroup.id}.segments.vcf.gz.tbi',
+            'ratios': prefix / f'{seqgroup.id}.ratios.tsv',
         }
 
     def queue_jobs(self, seqgroup: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:
@@ -258,19 +262,20 @@ class TrimOffSexChromosomes(stage.CohortStage):
     """
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path | str]:
-        cohort_prefix = self.get_stage_cohort_prefix(cohort)
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / self.name
 
         sgids_in_this_cohort = cohort.get_sequencing_group_ids()
 
         # returning an empty dictionary might cause the pipeline setup to break?
         # returning a string won't cause an existince check on this file, but will trick the pipeline into running?
         return_dict: dict[str, Path | str] = {
-            'placeholder': str(cohort_prefix / 'placeholder.txt'),
+            'placeholder': str(prefix / 'placeholder.txt'),
         }
 
         # load up the file of aneuploidies - I don't think the pipeline supports passing an input directly here
         # so... I'm making a similar path and manually string-replacing it
-        aneuploidy_file = str(cohort_prefix / 'aneuploidies.txt').replace(
+        aneuploidy_file = str(prefix / 'aneuploidies.txt').replace(
             self.name,
             'UpgradePedWithInferred',
         )
@@ -295,7 +300,7 @@ class TrimOffSexChromosomes(stage.CohortStage):
         for sgid in set(aneuploid_samples):
             if sgid not in sgids_in_this_cohort:
                 continue
-            return_dict[sgid] = cohort_prefix / f'{sgid}.segments.vcf.bgz'
+            return_dict[sgid] = prefix / f'{sgid}.segments.vcf.bgz'
 
         if len(return_dict) > 1:
             # if don't need the placeholder, remove it
@@ -337,10 +342,11 @@ class JointSegmentCnvVcfs(stage.CohortStage):
     """
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path]:
-        cohort_prefix = self.get_stage_cohort_prefix(cohort)
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / 'GCNVJointSegmentation'
         return {
-            'clustered_vcf': cohort_prefix / 'JointClusteredSegments.vcf.gz',
-            'clustered_vcf_idx': cohort_prefix / 'JointClusteredSegments.vcf.gz.tbi',
+            'clustered_vcf': prefix / 'JointClusteredSegments.vcf.gz',
+            'clustered_vcf_idx': prefix / 'JointClusteredSegments.vcf.gz.tbi',
         }
 
     def queue_jobs(self, cohort: targets.Cohort, inputs: stage.StageInput) -> stage.StageOutput:
@@ -406,17 +412,18 @@ class RecalculateClusteredQuality(stage.SequencingGroupStage):
         # identify the cohort that contains this SGID
         this_cohort = get_cohort_for_sgid(seqgroup.id)
 
-        cohort_prefix = self.get_stage_cohort_prefix(this_cohort)
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / this_cohort.id / self.name
 
         # this job runs per sample, on results with a cohort context
         # so we need to write the outputs to a cohort-specific location
         return {
-            'genotyped_intervals_vcf': cohort_prefix / f'{seqgroup.id}.intervals.vcf.gz',
-            'genotyped_intervals_vcf_index': cohort_prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
-            'genotyped_segments_vcf': cohort_prefix / f'{seqgroup.id}.segments.vcf.gz',
-            'genotyped_segments_vcf_index': cohort_prefix / f'{seqgroup.id}.segments.vcf.gz.tbi',
-            'denoised_copy_ratios': cohort_prefix / f'{seqgroup.id}.ratios.tsv',
-            'qc_status_file': cohort_prefix / f'{seqgroup.id}.qc_status.txt',
+            'genotyped_intervals_vcf': prefix / f'{seqgroup.id}.intervals.vcf.gz',
+            'genotyped_intervals_vcf_index': prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
+            'genotyped_segments_vcf': prefix / f'{seqgroup.id}.segments.vcf.gz',
+            'genotyped_segments_vcf_index': prefix / f'{seqgroup.id}.segments.vcf.gz.tbi',
+            'denoised_copy_ratios': prefix / f'{seqgroup.id}.ratios.tsv',
+            'qc_status_file': prefix / f'{seqgroup.id}.qc_status.txt',
         }
 
     def queue_jobs(self, sequencing_group: targets.SequencingGroup, inputs: stage.StageInput) -> stage.StageOutput:
@@ -454,14 +461,12 @@ class FastCombineGCNVs(stage.CohortStage):
     """
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path | str]:
-        """
-        This is now explicitly continuing from multicohort work, so the output path must include
-        pointers to both thetargets.MultiCohort and the targets.Cohort
-        """
-        cohort_prefix = self.get_stage_cohort_prefix(cohort)
+        wf = workflow.get_workflow()
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / self.name
+
         return {
-            'combined_calls': cohort_prefix / 'gcnv_joint_call.vcf.bgz',
-            'combined_calls_index': cohort_prefix / 'gcnv_joint_call.vcf.bgz.tbi',
+            'combined_calls': prefix / 'gcnv_joint_call.vcf.bgz',
+            'combined_calls_index': prefix / 'gcnv_joint_call.vcf.bgz.tbi',
         }
 
     def queue_jobs(self, cohort: targets.Cohort, inputs: stage.StageInput) -> stage.StageOutput:

--- a/src/cpg_gcnv/stages.py
+++ b/src/cpg_gcnv/stages.py
@@ -174,7 +174,7 @@ class UpgradePedWithInferred(stage.CohortStage):
 
 
 @stage.stage(required_stages=[PrepareIntervals, CollectReadCounts, DeterminePloidy])
-class CallGermlineCnvsWithGatk(stage.CohortStage):
+class GermlineCNV(stage.CohortStage):
     """
     The cohort-wide GermlineCNVCaller step, sharded across genome regions.
     This is separate from the DeterminePloidy stage so that the ProcessCohortCnvCallsToSgVcf
@@ -183,7 +183,7 @@ class CallGermlineCnvsWithGatk(stage.CohortStage):
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path]:
         wf = workflow.get_workflow()
-        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / 'GermlineCNV'
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / self.name
         return {name: prefix / f'{name}.tar.gz' for name in shard_items(name_only=True)}
 
     def queue_jobs(self, cohort: targets.Cohort, inputs: stage.StageInput) -> stage.StageOutput:
@@ -208,8 +208,8 @@ class CallGermlineCnvsWithGatk(stage.CohortStage):
         return self.make_outputs(cohort, data=outputs, jobs=jobs)
 
 
-@stage.stage(required_stages=[DeterminePloidy, CallGermlineCnvsWithGatk])
-class ProcessCohortCnvCallsToSgVcf(stage.SequencingGroupStage):
+@stage.stage(required_stages=[DeterminePloidy, GermlineCNV])
+class GermlineCNVCalls(stage.SequencingGroupStage):
     """
     Produces final individual VCF results by running PostprocessGermlineCNVCalls.
     """
@@ -223,7 +223,7 @@ class ProcessCohortCnvCallsToSgVcf(stage.SequencingGroupStage):
         this_cohort: targets.Cohort = get_cohort_for_sgid(seqgroup.id)
 
         wf = workflow.get_workflow()
-        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / this_cohort.id / 'GermlineCNVCalls'
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / this_cohort.id / self.name
         return {
             'intervals': prefix / f'{seqgroup.id}.intervals.vcf.gz',
             'intervals_index': prefix / f'{seqgroup.id}.intervals.vcf.gz.tbi',
@@ -245,7 +245,7 @@ class ProcessCohortCnvCallsToSgVcf(stage.SequencingGroupStage):
 
         jobs = postprocess_unclustered_calls(
             ploidy_calls_path=determine_ploidy['calls'],
-            shard_paths=inputs.as_dict(this_cohort, CallGermlineCnvsWithGatk),
+            shard_paths=inputs.as_dict(this_cohort, GermlineCNV),
             sample_index=sgid_ordering.index(seqgroup.id),
             job_attrs=self.get_job_attrs(seqgroup),
             output_prefix=str(self.get_stage_cohort_prefix(this_cohort) / seqgroup.id),
@@ -253,7 +253,7 @@ class ProcessCohortCnvCallsToSgVcf(stage.SequencingGroupStage):
         return self.make_outputs(seqgroup, data=outputs, jobs=jobs)
 
 
-@stage.stage(required_stages=[ProcessCohortCnvCallsToSgVcf, UpgradePedWithInferred])
+@stage.stage(required_stages=[GermlineCNVCalls, UpgradePedWithInferred])
 class TrimOffSexChromosomes(stage.CohortStage):
     """
     Trim off sex chromosomes for gCNV VCFs where the SGID is detected to be Aneuploid
@@ -315,7 +315,7 @@ class TrimOffSexChromosomes(stage.CohortStage):
         Plan to generate every file, so that the stage can be forced to re-run if needed
         """
         expected = self.expected_outputs(cohort)
-        germline_calls = inputs.as_dict_by_target(ProcessCohortCnvCallsToSgVcf)
+        germline_calls = inputs.as_dict_by_target(GermlineCNVCalls)
 
         cohort_segment_vcfs = {sgid: germline_calls[sgid]['segments'] for sgid in cohort.get_sequencing_group_ids()}
         jobs = trim_sex_chromosomes(
@@ -329,12 +329,12 @@ class TrimOffSexChromosomes(stage.CohortStage):
 @stage.stage(
     required_stages=[
         TrimOffSexChromosomes,
-        ProcessCohortCnvCallsToSgVcf,
+        GermlineCNVCalls,
         PrepareIntervals,
         UpgradePedWithInferred,
     ],
 )
-class JointSegmentCnvVcfs(stage.CohortStage):
+class GCNVJointSegmentation(stage.CohortStage):
     """
     various config elements scavenged from https://github.com/broadinstitute/gatk/blob/cfd4d87ec29ac45a68f13a37f30101f326546b7d/scripts/cnv_cromwell_tests/germline/cnv_germline_case_scattered_workflow.json#L26
     continuing adaptation of https://github.com/broadinstitute/gatk/blob/master/scripts/cnv_wdl/germline/joint_call_exome_cnvs.wdl
@@ -343,7 +343,7 @@ class JointSegmentCnvVcfs(stage.CohortStage):
 
     def expected_outputs(self, cohort: targets.Cohort) -> dict[str, Path]:
         wf = workflow.get_workflow()
-        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / 'GCNVJointSegmentation'
+        prefix = workflow.get_multicohort().analysis_dataset.prefix() / wf.name / cohort.id / self.name
         return {
             'clustered_vcf': prefix / 'JointClusteredSegments.vcf.gz',
             'clustered_vcf_idx': prefix / 'JointClusteredSegments.vcf.gz.tbi',
@@ -360,7 +360,7 @@ class JointSegmentCnvVcfs(stage.CohortStage):
         outputs = self.expected_outputs(cohort)
 
         # get the individual Segment VCFs
-        cnv_vcfs = inputs.as_dict_by_target(ProcessCohortCnvCallsToSgVcf)
+        cnv_vcfs = inputs.as_dict_by_target(GermlineCNVCalls)
 
         # and the dict of trimmed VCFs (can be empty)
         trimmed_vcfs = inputs.as_dict(cohort, TrimOffSexChromosomes)
@@ -396,7 +396,7 @@ class JointSegmentCnvVcfs(stage.CohortStage):
 
 
 @stage.stage(
-    required_stages=[JointSegmentCnvVcfs, CallGermlineCnvsWithGatk, ProcessCohortCnvCallsToSgVcf, DeterminePloidy],
+    required_stages=[GCNVJointSegmentation, GermlineCNV, GermlineCNVCalls, DeterminePloidy],
 )
 class RecalculateClusteredQuality(stage.SequencingGroupStage):
     """
@@ -433,17 +433,17 @@ class RecalculateClusteredQuality(stage.SequencingGroupStage):
         this_cohort = get_cohort_for_sgid(sequencing_group.id)
 
         # get the clustered VCF from the previous stage
-        joint_seg = inputs.as_dict(this_cohort, JointSegmentCnvVcfs)
+        joint_seg = inputs.as_dict(this_cohort, GCNVJointSegmentation)
 
         determine_ploidy = inputs.as_dict(this_cohort, DeterminePloidy)
-        gcnv_call_inputs = inputs.as_dict(sequencing_group, ProcessCohortCnvCallsToSgVcf)
+        gcnv_call_inputs = inputs.as_dict(sequencing_group, GermlineCNVCalls)
 
         # pull the json file with the sgid ordering
         sgid_ordering = fixed_sg_order(this_cohort)
 
         jobs = recalculate_clustered_calls(
             ploidy_calls_path=determine_ploidy['calls'],
-            shard_paths=inputs.as_dict(this_cohort, CallGermlineCnvsWithGatk),
+            shard_paths=inputs.as_dict(this_cohort, GermlineCNV),
             sample_index=sgid_ordering.index(sequencing_group.id),
             job_attrs=self.get_job_attrs(sequencing_group),
             output_prefix=str(self.get_stage_cohort_prefix(this_cohort) / sequencing_group.id),
@@ -517,7 +517,7 @@ class MergeCohortsgCNV(stage.MultiCohortStage):
 
 
 @stage.stage(required_stages=MergeCohortsgCNV, analysis_type='cnv', analysis_keys=['annotated_vcf'])
-class AnnotateCnvsWithSvAnnotate(stage.MultiCohortStage):
+class AnnotateCNV(stage.MultiCohortStage):
     """
     Smaller, direct annotation using SvAnnotate
     Add annotations, such as the inferred function and allele frequencies of variants, to final VCF.
@@ -560,15 +560,15 @@ class AnnotateCnvsWithSvAnnotate(stage.MultiCohortStage):
         return self.make_outputs(multicohort, data=outputs, jobs=jobs)
 
 
-@stage.stage(required_stages=AnnotateCnvsWithSvAnnotate, analysis_type='cnv')
-class AnnotateCnvsWithStrvctvre(stage.MultiCohortStage):
+@stage.stage(required_stages=AnnotateCNV, analysis_type='cnv')
+class AnnotateCNVVcfWithStrvctvre(stage.MultiCohortStage):
     def expected_outputs(self, multicohort: targets.MultiCohort) -> Path:
         return self.prefix / 'cnv_strvctvre_annotated.vcf.bgz'
 
     def queue_jobs(self, multicohort: targets.MultiCohort, inputs: stage.StageInput) -> stage.StageOutput:
         output = self.expected_outputs(multicohort)
 
-        input_vcf = inputs.as_str(multicohort, AnnotateCnvsWithSvAnnotate, key='annotated_vcf')
+        input_vcf = inputs.as_str(multicohort, AnnotateCNV, key='annotated_vcf')
 
         job = annotate_cnvs_with_strvctvre(
             input_vcf=input_vcf,
@@ -579,7 +579,7 @@ class AnnotateCnvsWithStrvctvre(stage.MultiCohortStage):
         return self.make_outputs(multicohort, data=output, jobs=job)
 
 
-@stage.stage(required_stages=AnnotateCnvsWithStrvctvre, analysis_type='single_dataset_cnv_annotated')
+@stage.stage(required_stages=AnnotateCNVVcfWithStrvctvre, analysis_type='single_dataset_cnv_annotated')
 class SplitAnnotatedCnvVcfByDataset(stage.DatasetStage):
     """
     takes the whole MultiCohort annotated VCF
@@ -598,7 +598,7 @@ class SplitAnnotatedCnvVcfByDataset(stage.DatasetStage):
     def queue_jobs(self, dataset: targets.Dataset, inputs: stage.StageInput) -> stage.StageOutput:
         output = self.expected_outputs(dataset)
         input_vcf = hail_batch.get_batch().read_input(
-            inputs.as_path(workflow.get_multicohort(), AnnotateCnvsWithStrvctvre),
+            inputs.as_path(workflow.get_multicohort(), AnnotateCNVVcfWithStrvctvre),
         )
 
         job = split_mc_vcf_by_dataset(
@@ -611,7 +611,7 @@ class SplitAnnotatedCnvVcfByDataset(stage.DatasetStage):
         return self.make_outputs(dataset, data=output, jobs=job)
 
 
-@stage.stage(required_stages=AnnotateCnvsWithStrvctvre, analysis_type='cnv')
+@stage.stage(required_stages=AnnotateCNVVcfWithStrvctvre, analysis_type='cnv')
 class AnnotateCohortCnv(stage.MultiCohortStage):
     """
     Rearrange the annotations across the cohort to suit Seqr
@@ -625,7 +625,7 @@ class AnnotateCohortCnv(stage.MultiCohortStage):
         Fire up the job to ingest the cohort VCF as a MT, and rearrange the annotations
         """
 
-        vcf_path = inputs.as_str(target=multicohort, stage=AnnotateCnvsWithStrvctvre)
+        vcf_path = inputs.as_str(target=multicohort, stage=AnnotateCNVVcfWithStrvctvre)
 
         output = self.expected_outputs(multicohort)
 


### PR DESCRIPTION
# Purpose

  - During the CPG-Flow migration i renamed some stages
  - At the same time, the cpg-flow implementation changed so that the cohorts all write to the bucket of cohort.dataset, instead of all cohorts writing to the run dataset

## Proposed Changes

  - renames the Stages back to the Prod-pipes versions. I don't like some of the names, but it's not worth $000+ of re-compute to generate all the data again
  - changes the cohort outputs paths to be `workflow.dataset.bucket / gcnv / cohort / stage_name`, matching what was done previously