### PR TITLE
fix(expected_outputs): paths from same source

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.6
+  VERSION: 0.1.7
   IMAGE_NAME: cpg-flow-gcnv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the gCNV workflow, migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gcnv.py) to the CPG-Flow framework.
 
-Current Version: 0.1.6
+Current Version: 0.1.7
 
 ## Purpose
 
@@ -41,7 +41,7 @@ Example Analysis-Runner invocation:
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gcnv:0.1.6 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gcnv:0.1.7 \
     --dataset DATASET \
     --description 'gCNV, CPG-flow' \
     -o gCNV_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='CPG-Flow implementation of the GCNV workflow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.6"
+version="0.1.7"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -107,7 +107,7 @@ hail = ["hail"]
 "src/cpg_gcnv/stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.6"
+current_version = "0.1.7"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_gcnv/stages.py
+++ b/src/cpg_gcnv/stages.py
@@ -248,7 +248,7 @@ class GermlineCNVCalls(stage.SequencingGroupStage):
             shard_paths=inputs.as_dict(this_cohort, GermlineCNV),
             sample_index=sgid_ordering.index(seqgroup.id),
             job_attrs=self.get_job_attrs(seqgroup),
-            output_prefix=str(self.get_stage_cohort_prefix(this_cohort) / seqgroup.id),
+            output_prefix=str(outputs['ratios']).removesuffix('.ratios.tsv'),
         )
         return self.make_outputs(seqgroup, data=outputs, jobs=jobs)
 
@@ -446,7 +446,7 @@ class RecalculateClusteredQuality(stage.SequencingGroupStage):
             shard_paths=inputs.as_dict(this_cohort, GermlineCNV),
             sample_index=sgid_ordering.index(sequencing_group.id),
             job_attrs=self.get_job_attrs(sequencing_group),
-            output_prefix=str(self.get_stage_cohort_prefix(this_cohort) / sequencing_group.id),
+            output_prefix=str(expected_out['qc_status_file']).removesuffix('.qc_status.txt'),
             clustered_vcf=str(joint_seg['clustered_vcf']),
             intervals_vcf=str(gcnv_call_inputs['intervals']),
             qc_file=str(expected_out['qc_status_file']),


### PR DESCRIPTION
# Purpose

  - broken pipeline - stage expected output paths and real output paths are generated differently
  - expected write - analysis dataset for the whole pipeilne
  - real write - dataset bucket the cohort belongs to

## Proposed Changes

  - uses the expected_outputs content to generate the path to write stage results to. Direct connection between expectation and results

## Also required

  - for the failing runs, cp the GermlineCNVCalls folder from the bucket it's currently in, to the bucket it should have been written to