### PR TITLE
fix(update_attributes): Fix END/SVLEN bug

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,7 +15,7 @@ on:
 permissions: {}
 
 env:
-  VERSION: 0.1.7
+  VERSION: 0.1.8
   IMAGE_NAME: cpg-flow-gcnv
   DOCKER_DEV: australia-southeast1-docker.pkg.dev/cpg-common/images-dev
   DOCKER_MAIN: australia-southeast1-docker.pkg.dev/cpg-common/images

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the gCNV workflow, migrated from [Production-Pipelines](https://github.com/populationgenomics/production-pipelines/blob/main/cpg_workflows/stages/gcnv.py) to the CPG-Flow framework.
 
-Current Version: 0.1.7
+Current Version: 0.1.8
 
 ## Purpose
 
@@ -41,7 +41,7 @@ Example Analysis-Runner invocation:
 ```bash
 analysis-runner \
     --skip-repo-checkout \
-    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gcnv:0.1.7 \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg-flow-gcnv:0.1.8 \
     --dataset DATASET \
     --description 'gCNV, CPG-flow' \
     -o gCNV_cpg-flow \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description='CPG-Flow implementation of the GCNV workflow'
 readme = "README.md"
 # currently cpg-flow is pinned to this version
 requires-python = ">=3.10,<3.12"
-version="0.1.7"
+version="0.1.8"
 license={ "file" = "LICENSE" }
 classifiers=[
     'Environment :: Console',
@@ -107,7 +107,7 @@ hail = ["hail"]
 "src/cpg_gcnv/stages.py" = ["ARG002"]
 
 [tool.bumpversion]
-current_version = "0.1.7"
+current_version = "0.1.8"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/cpg_gcnv/scripts/update_vcf_attributes.py
+++ b/src/cpg_gcnv/scripts/update_vcf_attributes.py
@@ -36,7 +36,7 @@ def update_vcf_attributes(input_tmp: str, output_file: str):
             start = int(l_split[1])
 
             # e.g. "AN_Orig=61;END=56855888;SVTYPE=DUP"
-            original_info: dict[str, str | int] = dict(el.split('=') for el in l_split[7].split(';'))
+            original_info: dict[str, str] = dict(el.split('=') for el in l_split[7].split(';'))
 
             # e.g. <DEL> -> DEL
             alt_allele = l_split[4][1:-1]
@@ -53,10 +53,10 @@ def update_vcf_attributes(input_tmp: str, output_file: str):
                 end = original_info['END']
             elif has_end:
                 end = original_info['END']
-                original_info['SVLEN'] = int(end) - start - 2
+                original_info['SVLEN'] = str(int(end) - start - 2)
             else:
                 svlen = int(original_info['SVLEN'])
-                original_info['END'] = start + svlen + 2
+                original_info['END'] = str(start + svlen + 2)
                 end = original_info['END']
 
             # make this unique after splitting (include alt allele)

--- a/src/cpg_gcnv/scripts/update_vcf_attributes.py
+++ b/src/cpg_gcnv/scripts/update_vcf_attributes.py
@@ -33,26 +33,36 @@ def update_vcf_attributes(input_tmp: str, output_file: str):
             if l_split[4] == '.':
                 continue
 
-            original_start = int(l_split[1])
+            start = int(l_split[1])
 
             # e.g. "AN_Orig=61;END=56855888;SVTYPE=DUP"
-            original_info: dict[str, str] = dict(el.split('=') for el in l_split[7].split(';'))
-
-            # steal the END integer
-            end_int = int(original_info['END'])
+            original_info: dict[str, str | int] = dict(el.split('=') for el in l_split[7].split(';'))
 
             # e.g. <DEL> -> DEL
             alt_allele = l_split[4][1:-1]
 
             # replace compound ID original ID
             chrom = l_split[0]
-            start = l_split[1]
+
+            # does this row have an END attribute?
+            has_end = 'END' in original_info
+            # does this row have an SVLEN attribute?
+            has_len = 'SVLEN' in original_info
+
+            if has_end and has_len:
+                end = original_info['END']
+            elif has_end:
+                end = original_info['END']
+                original_info['SVLEN'] = int(end) - start - 2
+            else:
+                svlen = int(original_info['SVLEN'])
+                original_info['END'] = start + svlen + 2
+                end = original_info['END']
 
             # make this unique after splitting (include alt allele)
-            l_split[2] = f'CNV_{chrom}_{start}_{end_int}_{alt_allele}'
+            l_split[2] = f'CNV_{chrom}_{start}_{end}_{alt_allele}'
 
             # update the INFO field with Length and Type (DUP/DEL, not "CNV")
-            original_info['SVLEN'] = str(end_int - original_start)
             l_split[7] = ';'.join(f'{k}={v}' for k, v in original_info.items())
 
             # put it together and what have you got?


### PR DESCRIPTION
# Purpose

  - New version of GATK image, new problems

## Proposed Changes

  - Old code always expected END to be present, but SVLEN to be missing
  - New output has either SVLEN always populated, and END sometimes (but not always) missing
  - Make floppy code that adjusts correctly to either attribute being missing, populating the opposite value

n.b. the `-2` modifier matches the natively populated SVLEN and END attributes. I assume this is caused by a numbering difference between Java/Python and the VCF native spec? IDK. Example of a real row with both attributes populated:

```
chrX    156001159       CNV_chrX_156001158_156010659    N       .       1606.63 FREQ    AN_Orig=207;END=156009565;SVLEN=9502;SVTYPE=DEL
```

## Checklist

- [ ] Related GitHub Issue created
- [ ] Tests covering new change
- [ ] Linting checks pass
